### PR TITLE
Upgrade commander for better typescript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "apollo-link": "^1.2.11",
     "apollo-link-batch-http": "^1.2.13",
     "apollo-link-retry": "^2.2.13",
-    "commander": "^2.14.1",
+    "commander": "^5.0.0",
     "eslint-config-prettier": "^6.10.1",
     "file-set": "^2.0.0",
     "fs-extra": "^5.0.0",

--- a/src/j1cli.ts
+++ b/src/j1cli.ts
@@ -8,7 +8,7 @@ import yaml from 'js-yaml';
 import { defaultAlertSettings } from '@jupiterone/jupiterone-alert-rules';
 import pAll from 'p-all';
 
-const program = require('commander');
+import { program } from 'commander';
 
 const writeFile = util.promisify(fs.writeFile);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1484,6 +1484,11 @@ commander@^2.14.1, commander@^2.9.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
+commander@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-5.0.0.tgz#dbf1909b49e5044f8fdaf0adc809f0c0722bdfd0"
+  integrity sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ==
+
 component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"


### PR DESCRIPTION
Pointing this to the `eslint` branch for now, will retarget to master after the other prs are merged. I tested out the cli from the commands things seem to work well. Mainly doing this because newer versions of the package add support for nested subcommands, which will be nice to have for the newer `integration` flow. Also types are much better and we can actually use the `import` syntax nicely.