### PR TITLE
ignore dist when running prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 .vscode
+dist


### PR DESCRIPTION
Small change. This just setups up prettier to ignore the dist folder.