### PR TITLE
Support bulkDelete client instance method (WIP)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/jupiterone-client-nodejs",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "A node.js client wrapper for JupiterOne public API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This function expects to be passed arrays of entities and/or
relationships as output from our queryV1 api. (They must have entity._id
or relationship._id properties.) This is because this operation is
inherently destructive, so destroy targets must be specified by their
globally unique _id values.