### PR TITLE
Add integrationInstance API to Node.js client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,24 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added the following methods to `JupiterOneClient`:
+
+  ```ts
+  const client = await new JupiterOneClient(options).init();
+
+  await client.integrationInstances.list();
+  await client.integrationInstances.get(id);
+  await client.integrationInstances.create(instance);
+  await client.integrationInstances.update(id, update);
+  await client.integrationInstances.delete(id);
+  ```
+
 ## 0.23.6
 
-- Replace deleteEntity with deleteEntityV2 
-- Add typings and resolve typing errors 
-- Remove entity property in `uploadGraphObjectsForDeleteSyncJob` 
-
+- Replace deleteEntity with deleteEntityV2
+- Add typings and resolve typing errors
+- Remove entity property in `uploadGraphObjectsForDeleteSyncJob`

--- a/README.md
+++ b/README.md
@@ -18,6 +18,20 @@ To install the client globally:
 npm install @jupiterone/jupiterone-client-nodejs -g
 ```
 
+## Using the Node.js client
+
+```javascript
+const { JupiterOneClient } = require('@jupiterone/jupiterone-client-nodejs');
+
+const j1Client = await new JupiterOneClient({
+  account: 'my-account-id',
+  accessToken: 'my-api-token',
+}).init();
+const integrationInstance = await j1Client.integrationInstances.get(
+  'my-integration-instance-id',
+);
+```
+
 ## Using the J1 CLI
 
 Usage:

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -50,7 +50,7 @@ export const DELETE_ENTITY = gql`
       timestamp: $timestamp
       hardDelete: $hardDelete
     ) {
-      entity 
+      entity
     }
   }
 `;

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,3 +58,38 @@ export type RelationshipForSync = RelationshipAdditionalProperties & {
   _fromEntityKey?: string;
   _toEntityKey?: string;
 };
+
+export enum IntegrationPollingInterval {
+  DISABLED = 'DISABLED',
+  THIRTY_MINUTES = 'THIRTY_MINUTES',
+  ONE_HOUR = 'ONE_HOUR',
+  FOUR_HOURS = 'FOUR_HOURS',
+  EIGHT_HOURS = 'EIGHT_HOURS',
+  TWELVE_HOURS = 'TWELVE_HOURS',
+  ONE_DAY = 'ONE_DAY',
+  ONE_WEEK = 'ONE_WEEK',
+}
+
+export interface IntegrationPollingIntervalCronExpression {
+  /**
+   * UTC day of week. 0-6 (sun-sat)
+   */
+  dayOfWeek?: number;
+  /**
+   * UTC hour, 0-23
+   */
+  hour?: number;
+}
+
+export interface IntegrationInstance<TConfig = any> {
+  id: string;
+  accountId: string;
+
+  config?: TConfig;
+  description?: string;
+  integrationDefinitionId: string;
+  name: string;
+  offsiteComplete?: boolean;
+  pollingInterval?: IntegrationPollingInterval;
+  pollingIntervalCronExpression?: IntegrationPollingIntervalCronExpression;
+}


### PR DESCRIPTION
### Added

- Added the following methods to `JupiterOneClient`:

  ```ts
  const client = await new JupiterOneClient(options).init();
  await client.integrationInstances.list();
  await client.integrationInstances.get(id);
  await client.integrationInstances.create(instance);
  await client.integrationInstances.update(id, update);
  await client.integrationInstances.delete(id);
  ```

---

This is required for a new tool we're building in order to delete integration instances for AWS accounts that have `Status: SUSPENDED`