### PR TITLE
Improve Integration Instances List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.25.2] - 2022-02-07
+
+### Added
+
+- Helper function to easily query GraphQL queries with a cursor
+- IntegrationInstances.list unit tests
+
+### Updated
+
+- Resolve TypeError when calling integrationInstances.list without an argument
+
 ## [0.25.1] - 2022-02-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/jupiterone-client-nodejs",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "A node.js client wrapper for JupiterOne public API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/example-testing-data/example-integration-instance.json
+++ b/src/example-testing-data/example-integration-instance.json
@@ -1,0 +1,15 @@
+{
+  "accountId": "a-j1-account",
+  "config": {
+    "@tag": { "AccountName": "Test" },
+    "apiUser": "an-api-user@jupiterone.com",
+    "apiToken": "***masked***"
+  },
+  "description": "An example integration instance",
+  "id": "abc",
+  "integrationDefinitionId": "def",
+  "name": "Test",
+  "pollingInterval": "ONE_WEEK",
+  "pollingIntervalCronExpression": null,
+  "__typename": "IntegrationInstance"
+}

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -288,3 +288,27 @@ export const DELETE_QUESTION = gql`
     }
   }
 `;
+
+export const LIST_INTEGRATION_INSTANCES = gql`
+  query ListIntegrationInstances($definitionId: String, $cursor: String) {
+    integrationInstances(definitionId: $definitionId, cursor: $cursor) {
+      instances {
+        accountId
+        config
+        description
+        id
+        integrationDefinitionId
+        name
+        pollingInterval
+        pollingIntervalCronExpression {
+          hour
+          dayOfWeek
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,7 +99,17 @@ export interface IntegrationPollingIntervalCronExpression {
   hour?: number;
 }
 
-export interface IntegrationInstance<TConfig = any> {
+interface IntegrationInstanceTag {
+  AccountName: string;
+}
+
+export interface IntegrationInstanceConfig {
+  '@tag': IntegrationInstanceTag;
+  apiUser: string;
+  apiToken: string;
+}
+
+export interface IntegrationInstance<TConfig = unknown> {
   id: string;
   accountId: string;
 
@@ -110,4 +120,19 @@ export interface IntegrationInstance<TConfig = any> {
   offsiteComplete?: boolean;
   pollingInterval?: IntegrationPollingInterval;
   pollingIntervalCronExpression?: IntegrationPollingIntervalCronExpression;
+}
+
+export interface ListIntegrationInstancesOptions {
+  definitionId?: string;
+  cursor?: string;
+}
+
+export interface PageInfo {
+  endCursor?: string;
+  hasNextPage: boolean;
+}
+
+export interface ListIntegrationInstances {
+  instances: IntegrationInstance<IntegrationInstanceConfig>[];
+  pageInfo: PageInfo;
 }

--- a/src/util/get-prop.ts
+++ b/src/util/get-prop.ts
@@ -1,0 +1,12 @@
+export const getProp = <T, V>(
+  object: T,
+  keys: string[] | string,
+  defaultVal?: V,
+): V | undefined => {
+  keys = Array.isArray(keys) ? keys : keys.split('.');
+  const result = object[keys[0]];
+  if (result && keys.length > 1) {
+    return getProp(result, keys.slice(1));
+  }
+  return result === undefined ? defaultVal : result;
+};

--- a/src/util/query/index.ts
+++ b/src/util/query/index.ts
@@ -1,0 +1,2 @@
+export * as QueryTypes from './types';
+export { query } from './query';

--- a/src/util/query/query.ts
+++ b/src/util/query/query.ts
@@ -1,0 +1,42 @@
+import { ApolloQueryResult } from 'apollo-client';
+import { QueryTypes } from './';
+import { PageInfo } from '../../types';
+import { getProp } from '../get-prop';
+
+export const query = async <T, V>(
+  fn: QueryTypes.QueryFunction<T>,
+  options: QueryTypes.QueryOptions,
+): Promise<QueryTypes.QueryResults<V>> => {
+  const result: QueryTypes.QueryResults<V> = {
+    data: [],
+    errors: [],
+  };
+
+  let cursor: string | undefined;
+
+  do {
+    const res = await fn({ cursor });
+
+    if (res.errors) {
+      result.errors = [...result.errors, ...res.errors];
+    }
+
+    const data = getProp<ApolloQueryResult<T>, Array<V>>(
+      res,
+      options.dataPath,
+      [],
+    );
+
+    if (data) {
+      result.data = [...result.data, ...data];
+    }
+
+    const cursorInfo = getProp<ApolloQueryResult<T>, PageInfo>(
+      res,
+      options.cursorPath,
+    );
+    cursor = cursorInfo?.endCursor;
+  } while (cursor);
+
+  return result;
+};

--- a/src/util/query/types.ts
+++ b/src/util/query/types.ts
@@ -1,0 +1,20 @@
+import { ApolloQueryResult } from 'apollo-client';
+import { GraphQLError } from 'graphql';
+
+export interface QueryResults<T> {
+  data: Array<T>;
+  errors: ReadonlyArray<GraphQLError>;
+}
+
+export interface QueryOptions {
+  dataPath: string;
+  cursorPath: string;
+}
+
+export interface QueryFunctionProps {
+  cursor: string | undefined;
+}
+
+export interface QueryFunction<T> {
+  (options: QueryFunctionProps): Promise<ApolloQueryResult<T>>;
+}


### PR DESCRIPTION
- Add helper function to easily query GraphQL queries with a cursor
- Resolve TypeError when calling `integrationInstances.list` without
an argument
- Add `integrationInstances.list` unit tests