### PR TITLE
Fix detection of inline question rule bodies when creating/updating a…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -480,7 +480,7 @@ export class JupiterOneClient {
   }
 
   async mutateAlertRule(rule: any, update: any) {
-    const inlineQuestion = !!update?.instance?.question;
+    const inlineQuestion = !!(rule.instance?.question);
     let mutation;
     if (inlineQuestion) {
       mutation = update ? UPDATE_INLINE_ALERT_RULE : CREATE_INLINE_ALERT_RULE;


### PR DESCRIPTION
…lert rule

This was causing the client to always reach this mutation:
https://github.com/JupiterOne/jupiterone-client-nodejs/blob/81716a3b2b1e2d236a822743135594fcf90ffcfd/src/queries.ts#L142-L153

It should reach this one:
https://github.com/JupiterOne/jupiterone-client-nodejs/blob/81716a3b2b1e2d236a822743135594fcf90ffcfd/src/queries.ts#L129-L140