### PR TITLE
Adds error handling in networkRequest

### DIFF
--- a/src/networkRequest.ts
+++ b/src/networkRequest.ts
@@ -6,5 +6,19 @@ export const networkRequest = async (
   url: string,
 ): Promise<Record<string, unknown>> => {
   const result = await fetch(url);
+
+  const { status, headers } = result;
+
+  if (status < 200 || status >= 300) {
+    const body = await result.text();
+    throw new Error(`HTTP request failed (${status}): ${body}`);
+  }
+
+  const contentType = headers.get('content-type');
+  if (contentType?.includes('application/json') === false) {
+    const body = await result.text();
+    throw new Error(`HTTP response is not JSON but ${contentType}: ${body}`);
+  }
+
   return result.json();
 };


### PR DESCRIPTION
Sometimes the requets fails randomly and/or the content type is not json. The lack of error handling makes consumers unable to catch the error to see what went wrong.

This commit adds error handling for both cases when the request fails (status !== 2xx) and when the content-type is not json.

I'd recommend to test it on your side as well because the behavior of the backend is not entirely known by me. 