### PR TITLE
Fix content-type header to prevent merging of duplicates

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -328,7 +328,7 @@ export class JupiterOneClient {
     this.headers = {
       Authorization: `Bearer ${token}`,
       'LifeOmic-Account': this.account,
-      'Content-Type': 'application/json',
+      'content-type': 'application/json',
     };
 
     const uri = this.useRulesEndpoint ? this.rulesEndpoint : this.queryEndpoint;


### PR DESCRIPTION
Hello

We've noticed that when the J1 node client targets a proxy instead of targeting JupiterOne's API directly, two headers of the same name are sent. Since it's HTTP 1.1, AWS Load Balancer seems to merge the two values into comma separated lists, which then eventually breaks when forwarding the request later to JupiterOne.

I can test by logging in the apollo-lin-back-http package locally
https://github.com/apollographql/apollo-link/blob/master/packages/apollo-link-batch-http/src/batchHttpLink.ts#L141
And I can see that the two headers are there in different casing, one added by J1 and another by apollo.
```
{
  method: 'POST',
  headers: {
    accept: '*/*',
    'content-type': 'application/json',
    Authorization: 'Bearer hello',
    'LifeOmic-Account': '...',
    'Content-Type': 'application/json'
  },
  credentials: undefined
}
```

I can't understand why it works when targeting J1 API directly because doing a curl with the same headers causes a fail
```
curl https://api.eu.jupiterone.io/graphql -H 'Authorization: Bearer ...' -X POST -H 'LifeOmic-Account: ...' -H 'content-type: application/json' -H 'Content-Type: application/json' --http1.1
```

This small fix makes sure that the header from J1 and from apollo are just using the same key. Tested locally and it worked fine for us. Didn't delete the header entirely since it's used in other places and didn't want to risk breaking that.

Ran a sync job that uses the `uploadGraphObjectsForSyncJob` and it still worked fine.