### PR TITLE
Replace skip limit pagination with cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.1.0] - 2024-07-23
+
+- Update the `queryv1` function to use cursors instead of the legacy `LIMIT SKIP` pagination approach
+- Add support for a progress bar
+
 ## [2.0.1] - 2024-07-02
 
 - Converted `Content-Type` request header to lower case. This conforms to https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2. And also addresses an issue where Content-Type and content-type headers were both being added.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "apollo-link-retry": "^2.2.13",
     "bunyan-category": "^0.4.0",
     "chalk": "^4.1.2",
+    "cli-progress": "^3.12.0",
     "commander": "^5.0.0",
     "graphql": "^14.6.0",
     "graphql-tag": "^2.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/jupiterone-client-nodejs",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "A node.js client wrapper for JupiterOne public API",
   "repository": {
     "type": "git",

--- a/src/example-testing-data/example-data.json
+++ b/src/example-testing-data/example-data.json
@@ -3,8 +3,7 @@
     "queryV1": {
       "type": "deferred",
       "data": null,
-      "url": "https://an-s3-bucket/temp/j1dev/deferred/abc/state.json",
-      "__typename": "QueryV1Response"
+      "url": "https://an-s3-bucket/temp/j1dev/deferred/abc/state.json"
     }
   },
   "loading": false,

--- a/src/example-testing-data/example-deferred-result.json
+++ b/src/example-testing-data/example-deferred-result.json
@@ -1,5 +1,32 @@
 {
   "status": "COMPLETED",
   "url": "https://an-s3-bucket/temp/j1dev/deferred/abc/state.json",
-  "correlationId": "abc"
+  "correlationId": "abc",
+  "data": {
+    "id": "abc",
+    "entity": {
+      "_class": ["Class"],
+      "_type": ["an_example_type"],
+      "_key": "abc",
+      "displayName": "display_name",
+      "_integrationType": "github",
+      "_integrationClass": ["ITS", "SCM", "VCS", "VersionControl"],
+      "_integrationDefinitionId": "def",
+      "_integrationName": "JupiterOne",
+      "_beginOn": "2021-12-03T01:10:33.604Z",
+      "_id": "ghi",
+      "_integrationInstanceId": "nmi",
+      "_version": 11,
+      "_accountId": "an_account",
+      "_deleted": false,
+      "_source": "source",
+      "_createdOn": "2021-08-20T20:15:09.583Z"
+    },
+    "properties": {
+      "disabled": false,
+      "empty": false,
+      "fork": false,
+      "forkingAllowed": false
+    }
+  }
 }

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -111,6 +111,8 @@ export const QUERY_V1 = gql`
     $includeDeleted: Boolean
     $deferredResponse: DeferredResponseOption
     $deferredFormat: DeferredResponseFormat
+    $cursor: String
+    $flags: QueryV1Flags
   ) {
     queryV1(
       query: $query
@@ -118,6 +120,8 @@ export const QUERY_V1 = gql`
       includeDeleted: $includeDeleted
       deferredResponse: $deferredResponse
       deferredFormat: $deferredFormat
+      cursor: $cursor
+      flags: $flags
     ) {
       type
       data

--- a/yarn.lock
+++ b/yarn.lock
@@ -1344,6 +1344,13 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
+cli-progress@^3.12.0:
+  version "3.12.0"
+  resolved "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz#807ee14b66bcc086258e444ad0f19e7d42577942"
+  integrity sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==
+  dependencies:
+    string-width "^4.2.3"
+
 cli-spinners@^2.5.0:
   version "2.6.1"
   resolved "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz"
@@ -3589,7 +3596,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-string-width@^4.1.0, string-width@^4.2.0:
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==


### PR DESCRIPTION
* Changed the way the sdk does pagination to the proper method of using a cursor, the current implementation was resulting in duplicate entities and is a known artifact of the neo4j upgrade
* Add the use of variable result size
* Add a progress bar
* Did some other minor cleanup